### PR TITLE
Fix: Add missing separator/comparator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "ext-json": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
-        "ext-xml": "*"
+        "ext-xml": "*",
+        "sebastian/comparator": "^2.0.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.4.1"


### PR DESCRIPTION
This PR

* [x] adds `sebastian/comparator` as it is required by this package