### PR TITLE
Fix: Use assertSame() instead of assertEquals()

### DIFF
--- a/tests/Constraint/DirectoryExistsTest.php
+++ b/tests/Constraint/DirectoryExistsTest.php
@@ -21,7 +21,7 @@ class DirectoryExistsTest extends TestCase
         $constraint = new DirectoryExists();
 
         $this->assertCount(1, $constraint);
-        $this->assertEquals('directory exists', $constraint->toString());
+        $this->assertSame('directory exists', $constraint->toString());
     }
 
     public function testEvaluateReturnsFalseWhenDirectoryDoesNotExist()
@@ -51,7 +51,7 @@ class DirectoryExistsTest extends TestCase
         try {
             $constraint->evaluate($directory);
         } catch (ExpectationFailedException $e) {
-            $this->assertEquals(
+            $this->assertSame(
                 <<<PHP
 Failed asserting that directory "$directory" exists.
 


### PR DESCRIPTION
This PR

* [x] uses `assertSame()` instead of `assertEquals()`

Follows #39.

💁‍♂️ Better to be as strict as possible and only losen constraints when intended.