### PR TITLE
Enhancement: Add composer scripts to run tests and php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,5 +48,16 @@
         "classmap": [
             "tests/"
         ]
+    },
+    "scripts": {
+        "all": [
+            "@cs",
+            "@test"
+        ],
+        "cs": "php-cs-fixer fix --verbose",
+        "test": [
+            "@composer install",
+            "phpunit"
+        ]
     }
 }


### PR DESCRIPTION
This PR

* [x] adds `composer` scripts for running tests and `php-cs-fixer`

💁‍♂️ For reference, see https://getcomposer.org/doc/articles/scripts.md#running-scripts-manually.

Run

```
$ composer cs
```

to run `php-cs-fixer`, or run

```
$ composer test
```

to run the tests, or run

```
$ composer all
```

to run all.

Alternatively, of course, we could add a `Makefile`. Not sure what @sebastianbergmann's stance is on this, though. What do you think?
